### PR TITLE
Use HTTPS for submodules, so that jenkins can test the repos without …

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "just-dockerfiles"]
 	path = just-dockerfiles
-	url = git@github.com:jmchilton/just-dockerfiles.git
+	url = https://github.com/jmchilton/just-dockerfiles.git


### PR DESCRIPTION
…needing SSH keys.

Same reasoning as https://github.com/jmchilton/just-dockerfiles/pull/1
